### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A high-performance MCP (Model Context Protocol) server for Apache CloudStack API integration. This server provides comprehensive tools for managing CloudStack infrastructure through the MCP protocol, enabling seamless integration with AI assistants and automation tools.
 
+<a href="https://glama.ai/mcp/servers/@phantosmax/cloudstack-mcp-server">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@phantosmax/cloudstack-mcp-server/badge" alt="CloudStack Server MCP server" />
+</a>
+
 ## Features
 
 - **🔧 Complete VM Lifecycle Management**: Deploy, start, stop, reboot, and destroy virtual machines


### PR DESCRIPTION
This PR adds a badge for the [CloudStack MCP Server](https://glama.ai/mcp/servers/@phantosmax/cloudstack-mcp-server) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@phantosmax/cloudstack-mcp-server">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@phantosmax/cloudstack-mcp-server/badge" alt="CloudStack Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.